### PR TITLE
Give up GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Calling function blur...finished.
 Elapsed time: 0.00000 seconds
 ```
 
-## We're Using GitHub Under Protest ==
+## We're Using GitHub Under Protest
 
 Note: we encourage you to add this section to your existing `README.md` on your GitHub project.
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Calling function blur...finished.
 Elapsed time: 0.00000 seconds
 ```
 
-Note: we encourage you to add the below to your existing `README.md` on your GitHub project.
+## We're Using GitHub Under Protest ==
 
-== We're Using GitHub Under Protest ==
+Note: we encourage you to add this section to your existing `README.md` on your GitHub project.
 
 This project is currently hosted on GitHub.  This is not ideal; GitHub is a
 proprietary, trade-secret system that is not Free and Open Souce Software

--- a/README.md
+++ b/README.md
@@ -70,3 +70,28 @@ clang -march=native -std=c18 -Wall -Wextra -pthread -O3 -DNDEBUG -o filter filte
 Calling function blur...finished.
 Elapsed time: 0.00000 seconds
 ```
+
+Note: we encourage you to add the below to your existing `README.md` on your GitHub project.
+
+== We're Using GitHub Under Protest ==
+
+This project is currently hosted on GitHub.  This is not ideal; GitHub is a
+proprietary, trade-secret system that is not Free and Open Souce Software
+(FOSS).  We are deeply concerned about using a proprietary system like GitHub
+to develop our FOSS project.  We have an
+[open {bug ticket, mailing list thread, etc.} ](INSERT_LINK) where the
+project contributors are actively discussing how we can move away from GitHub
+in the long term.  We urge you to read about the
+[Give up GitHub](https://GiveUpGitHub.org) campaign from
+[the Software Freedom Conservancy](https://sfconservancy.org) to understand
+some of the reasons why GitHub is not a good place to host FOSS projects.
+
+If you are a contributor who personally has already quit using GitHub, please
+[check this resource](INSERT_LINK) for how to send us contributions without
+using GitHub directly.
+
+Any use of this project's code by GitHub Copilot, past or present, is done
+without our permission.  We do not consent to GitHub's use of this project's
+code in Copilot.
+
+![Logo of the GiveUpGitHub campaign](https://sfconservancy.org/static/img/GiveUpGitHub.png)


### PR DESCRIPTION
Add the awareness-raising section recommended by the SFC for the GiveUpGitHub.org campaign.